### PR TITLE
Add basic Session page view

### DIFF
--- a/app/assets/javascripts/sessions_controller.js.coffee
+++ b/app/assets/javascripts/sessions_controller.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sessions_controller.css.scss
+++ b/app/assets/stylesheets/sessions_controller.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sessions_controller controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,5 @@
+class SessionsController < ApplicationController
+  def index
+    @sessions = Session.all
+  end
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,0 +1,21 @@
+<table>
+  <tr>
+    <th>GameName</th>
+    <th>Played Date</th>
+    <th>Players</th>
+  </tr>
+
+  <% @sessions.each do |session| %>
+      <tr>
+        <td><%= session.game.name %></td>
+        <td><%= session.played %></td>
+        <td>
+          <table>
+            <% session.session_player.each do |player| %>
+                <tr><td><%= player.player.name %> (<%= player.placing %>)</td></tr>
+            <% end %>
+          </table>
+        </td>
+      </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   
   resources :players
 
+  resources :sessions do
+    resources :session_players
+  end
+
   root 'welcome#index'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionController::TestCase
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get show" do
+    get :show
+    assert_response :success
+  end
+
+end

--- a/test/helpers/sessions_controller_helper_test.rb
+++ b/test/helpers/sessions_controller_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class SessionsControllerHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
Includes game name, played date, and list of players (and their placing).

Can view at `/sessions` url.

Working on the create page next. In the meantime, here is some sample code to insert 2 sessions with 2 players each (assumes you have 2 players and 2 games with ids 1 and 2).

```
--insert session
INSERT INTO sessions (played, notes, game_id, created_at, updated_at) VALUES
('2014-11-04', 'notes went here', 1, '2014-11-04', '2014-11-04');
--player 1 came in first and on team 2
INSERT INTO session_players (score, "placing", team_number, player_id, session_id, created_at, updated_at) VALUES
  (11, 1, 2, 1, 1, '2014-11-04', '2014-11-04');
--player 2 came in second and on team 2
INSERT INTO session_players (score, "placing", team_number, player_id, session_id, created_at, updated_at) VALUES
  (11, 2, 2, 2, 1, '2014-11-04', '2014-11-04');
--insert session
INSERT INTO sessions (played, notes, game_id, created_at, updated_at) VALUES
('2014-11-01', 'more test notes?', 2, '2014-11-01', '2014-11-01');
--player 1 came in second and on team 1
INSERT INTO session_players (score, "placing", team_number, player_id, session_id, created_at, updated_at) VALUES
  (11, 1, 2, 1, 2, '2014-11-01', '2014-11-01');
--player 2 came in first and on team 1
INSERT INTO session_players (score, "placing", team_number, player_id, session_id, created_at, updated_at) VALUES
  (11, 2, 2, 2, 2, '2014-11-01', '2014-11-01');
```
