### PR TITLE
Move coop Value From Game To Session

### DIFF
--- a/app/assets/javascripts/controllers/GamesAddCtrl.js.coffee
+++ b/app/assets/javascripts/controllers/GamesAddCtrl.js.coffee
@@ -1,8 +1,9 @@
 angular.module('BoardgameTracker')
 .controller 'GamesAddCtrl', ['$scope', '$stateParams', '$state', 'GamesService', ($scope, $stateParams, $state, GamesService) ->
-  $scope.game = 
-    coop: false
-    
+  GamesService.New()
+  .then (data) ->
+    $scope.game = data
+
   $scope.add = -> 
   	GamesService.Add($scope.game)
     .then (data) -> 

--- a/app/assets/javascripts/services/GamesService.js.coffee
+++ b/app/assets/javascripts/services/GamesService.js.coffee
@@ -22,5 +22,12 @@ angular.module('BoardgameTracker').factory 'GamesService', [
         q.resolve(data)
         return
       return q.promise
+    New: ->
+      q = $q.defer()
+      $http.get('/games/new')
+      .success (data) ->
+        q.resolve(data)
+        return
+      return q.promise
   }
 ]

--- a/app/assets/javascripts/templates/games-add.html
+++ b/app/assets/javascripts/templates/games-add.html
@@ -11,9 +11,12 @@
         </md-input-container>
     </md-content>
     <md-content layout-padding layout="row" layout-sm="column">
-      <md-switch ng-model="game.coop" class="md-primary" aria-label="Co-op">
-        Co-op
-      </md-switch>
+      <md-input-container>
+        <label>Game Type</label>
+        <md-select ng-model="game.game_type" required>
+          <md-option ng-repeat="(key,value) in game.game_types" ng-value="value*1">{{key}}</md-option>
+        </md-select>
+      </md-input-container>
       <md-input-container>
         <label>Image Url</label>
         <input ng-model="game.image">

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -20,7 +20,7 @@ class GamesController < ApplicationController
 
   private
     def game_params
-      p = params.require(:game).permit(:name, :coop, :game_type, :description, :image)
+      p = params.require(:game).permit(:name, :game_type, :description, :image)
       p[:game_type] = p[:game_type].to_i unless p[:game_type].nil?
       return p
     end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,9 @@
 class GamesController < ApplicationController
+  def new
+    game = Game.new
+
+    render :json => game, :serializer => Games::NewSerializer
+  end
 
   def create
     @game = Game.new(game_params)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -20,6 +20,8 @@ class GamesController < ApplicationController
 
   private
     def game_params
-      params.require(:game).permit(:name, :coop, :description, :image)
+      p = params.require(:game).permit(:name, :coop, :game_type, :description, :image)
+      p[:game_type] = p[:game_type].to_i unless p[:game_type].nil?
+      return p
     end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,5 +1,10 @@
 class Game < ActiveRecord::Base
   has_many :sessions
+  enum game_type: {
+      mixed: 0,
+      competitive: 1,
+      coop: 2
+  }
 
   default_scope { order('name asc') }
 

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,3 +1,3 @@
 class GameSerializer < ActiveModel::Serializer
-  attributes :id, :name, :coop, :description, :image
+  attributes :id, :name, :game_type, :description, :image
 end

--- a/app/serializers/games/new_serializer.rb
+++ b/app/serializers/games/new_serializer.rb
@@ -1,0 +1,7 @@
+class Games::NewSerializer < GameSerializer
+  attributes :game_types
+
+  def game_types
+    Game.game_types
+  end
+end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,14 +1,14 @@
 <table>
   <tr>
     <th>Name</th>
-    <th>Co-op</th>
+    <th>Game Type</th>
     <th>Description</th>
   </tr>
  
   <% @games.each do |game| %>
     <tr>
       <td><%= game.name %></td>
-      <td><%= game.coop %></td>
+      <td><%= game.game_type %></td>
       <td><%= game.description %></td>
     </tr>
   <% end %>

--- a/db/migrate/20160610052711_add_column_gametype_to_game.rb
+++ b/db/migrate/20160610052711_add_column_gametype_to_game.rb
@@ -1,0 +1,10 @@
+class AddColumnGametypeToGame < ActiveRecord::Migration
+  def up
+    add_column :games, :game_type, :integer, :null => false, default: 1
+    change_column_default :games, :game_type, nil
+  end
+
+  def down
+    remove_column :games, :game_type
+  end
+end

--- a/db/migrate/20160611052115_remove_column_coop_from_game.rb
+++ b/db/migrate/20160611052115_remove_column_coop_from_game.rb
@@ -1,0 +1,6 @@
+class RemoveColumnCoopFromGame < ActiveRecord::Migration
+  def change
+    Rake::Task['migrate_data_to_game_gametype'].invoke
+    remove_column :games, :coop, :boolean
+  end
+end

--- a/db/migrate/20160611060216_update_team_number__on_session_players.rb
+++ b/db/migrate/20160611060216_update_team_number__on_session_players.rb
@@ -1,0 +1,5 @@
+class UpdateTeamNumberOnSessionPlayers < ActiveRecord::Migration
+  def change
+    change_column :session_players, :team_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20160611052115) do
   create_table "session_players", force: true do |t|
     t.integer  "score"
     t.integer  "placing"
-    t.integer  "team_number"
+    t.string   "team_number"
     t.integer  "player_id"
     t.integer  "session_id"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151018033613) do
+ActiveRecord::Schema.define(version: 20160610052711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20151018033613) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image"
+    t.integer  "game_type",   null: false
   end
 
   create_table "players", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160610052711) do
+ActiveRecord::Schema.define(version: 20160611052115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 20160610052711) do
   create_table "games", force: true do |t|
     t.string   "name"
     t.text     "description"
-    t.boolean  "coop"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image"

--- a/lib/tasks/migrate_data_to_game_gametype.rake
+++ b/lib/tasks/migrate_data_to_game_gametype.rake
@@ -1,0 +1,13 @@
+require 'rake'
+
+task :migrate_data_to_game_gametype => :environment do
+  desc "Update co-op games to co-op game type"
+  games = Game.where(coop: true)
+
+  puts "Going to update #{games.count} games"
+  ActiveRecord::Base.transaction do
+    games.each do |game|
+      game.update_attributes!(:game_type => Game.game_types[:coop])
+    end
+  end
+end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -2,12 +2,13 @@ require 'test_helper'
 
 class GamesControllerTest < ActionController::TestCase
   test 'should post create' do
-    @new_game = {
+    new_game = {
         'name' => 'test',
-        'description' => 'test desc'
+        'description' => 'test desc',
+        'game_type' => Game.game_types[:mixed]
     }
 
-    post :create, {'game_id' => 1, 'game' => @new_game}
+    post :create, {'game_id' => 1, 'game' => new_game}
     assert_response :success
   end
 
@@ -18,11 +19,11 @@ class GamesControllerTest < ActionController::TestCase
   end
 
   test 'should get individual game from view' do
-    @game = Game.find(ActiveRecord::FixtureSet.identify(:game_one))
+    game = Game.find(ActiveRecord::FixtureSet.identify(:game_one))
 
-    get :show, id: @game.id, :format => "json"
+    get :show, id: game.id, :format => "json"
     assert_response :success
     result = JSON.parse(response.body)
-    assert_equal @game.name, result["name"]
+    assert_equal game.name, result["name"]
   end
 end

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -3,7 +3,9 @@
 game_one:
   name: Game1
   description: Game 1 desc
+  game_type: <%= Game.game_types[:coop] %>
 
 game_two:
   name: Game2
   description: Game 2 desc
+  game_type: <%= Game.game_types[:competitive] %>


### PR DESCRIPTION
It is possible for a game to be played as a co-op or competitively. This needs to be reflected by identifying the individual session as a co-op or competitive. To allow for this design, instead of a `coop` boolean on the Game object, create an enum `game_type` that can define how the game can behave. The individual session can track the competitiveness of the game through the `team_number` values on each `session_player`.

This work creates this new design and migrates all existing co-op game data over to it.