### PR TITLE
Add Support For Games With Null Stats

### DIFF
--- a/app/assets/javascripts/controllers/GameCtrl.js.coffee
+++ b/app/assets/javascripts/controllers/GameCtrl.js.coffee
@@ -3,7 +3,10 @@ angular.module('BoardgameTracker')
   GamesService.Get($stateParams.id)
     .then (data) -> 
       $scope.game = data
-      $scope.game.best_player.percentage = Math.round $scope.game.best_player.percent * 100
-      $scope.game.worst_player.percentage = Math.round $scope.game.worst_player.percent * 100
+
+      best_player = $scope.game.best_player
+      worst_player = $scope.game.worst_player
+      $scope.game.best_player.percentage = Math.round(best_player.percent * 100) if best_player?
+      $scope.game.worst_player.percentage = Math.round(worst_player.percent * 100) if worst_player?
       return
   ]

--- a/app/assets/javascripts/templates/game.html
+++ b/app/assets/javascripts/templates/game.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<div layout="row" layout-xs="column">
+<div layout="row" layout-xs="column" ng-if="game.best_player">
     <div flex>
         <h3>Best Player</h3>
         <div layout="column">
@@ -36,3 +36,4 @@
         </div>
     </div>
 </div>
+<h3 ng-if="game.best_player == null">No Stats (Yet)</h3>

--- a/app/models/concerns/games/stats_retriever.rb
+++ b/app/models/concerns/games/stats_retriever.rb
@@ -27,6 +27,7 @@ module Games
         end
 
         def to_stats (game_total)
+          return nil unless game_total
           player_stats = Games::PlayerStats.new
           player_stats.win_percent = game_total.win_percentage
           player_stats.player = Player.find(game_total.player_id)

--- a/app/serializers/games/show_serializer.rb
+++ b/app/serializers/games/show_serializer.rb
@@ -2,10 +2,22 @@ class Games::ShowSerializer < GameSerializer
   attributes :best_player, :worst_player
 
   def best_player
-    {:percent => object.best_player.win_percent, :name => object.best_player.player.name }
+    stats = object.best_player
+    return nil unless stats
+
+    {
+        :percent => stats.win_percent,
+        :name => stats.player.name
+    }
   end
 
   def worst_player
-    {:percent => object.worst_player.win_percent, :name => object.worst_player.player.name }
+    stats = object.worst_player
+    return nil unless stats
+
+    {
+        :percent => stats.win_percent,
+        :name => stats.player.name
+    }
   end
 end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -26,4 +26,19 @@ class GamesControllerTest < ActionController::TestCase
     result = JSON.parse(response.body)
     assert_equal game.name, result["name"]
   end
+
+  test 'should have no stats on new game' do
+    new_game = {
+        'name' => 'test',
+        'description' => 'test desc',
+        'game_type' => Game.game_types[:mixed]
+    }
+    post :create, {'game_id' => 1, 'game' => new_game}
+
+    get :show, id: response.body, :format => "json"
+
+    parsed_game = JSON.parse(response.body)
+    assert_nil parsed_game[:best_player]
+    assert_nil parsed_game[:worst_player]
+  end
 end


### PR DESCRIPTION
Prevent page from crashing when no stats are present.
Show a default message if game has no stats.