### PR TITLE
Add session count to most_played_game stat

### DIFF
--- a/rails/app/models/concerns/player_stats/session_stats.rb
+++ b/rails/app/models/concerns/player_stats/session_stats.rb
@@ -14,12 +14,13 @@ module PlayerStats
 
         game_result = Game.from(subquery)
                       .group('game_id')
-                      .select('game_id')
+                      .select('game_id, count(game_id) as session_count')
                       .order('count(game_id) desc')
                       .first
         return nil unless game_result
 
-        return Game.find(game_result.game_id)
+        game = Game.find(game_result.game_id)
+        return PlayerStats::GameSessionCount.new(game, game_result.session_count)
       end
   end
 end

--- a/rails/app/models/player_stats/game_session_count.rb
+++ b/rails/app/models/player_stats/game_session_count.rb
@@ -1,0 +1,10 @@
+module PlayerStats
+  class GameSessionCount
+    def initialize(game, session_count)
+      @game = game
+      @session_count = session_count
+    end
+
+    attr_reader :game, :session_count
+  end
+end

--- a/rails/app/models/player_stats/game_win_percent.rb
+++ b/rails/app/models/player_stats/game_win_percent.rb
@@ -5,6 +5,6 @@ module PlayerStats
       @win_percent = win_percent
     end
 
-    attr_accessor :game, :win_percent
+    attr_reader :game, :win_percent
   end
 end

--- a/rails/test/models/concerns/player_stats/session_stats_test.rb
+++ b/rails/test/models/concerns/player_stats/session_stats_test.rb
@@ -41,7 +41,8 @@ class SessionStatsTest < ActiveSupport::TestCase
 
       most_played_game = PlayerStatistic.new(player.id).most_played_game
 
-      assert_equal game_one, most_played_game
+      assert_equal game_one, most_played_game.game
+      assert_equal 2, most_played_game.session_count
     end
 
     should 'count sessions with duplicate players once' do
@@ -53,7 +54,8 @@ class SessionStatsTest < ActiveSupport::TestCase
 
       most_played_game = PlayerStatistic.new(player.id).most_played_game
 
-      assert_equal game_one, most_played_game
+      assert_equal game_one, most_played_game.game
+      assert_equal 3, most_played_game.session_count
     end
   end
 end


### PR DESCRIPTION
Forgot this in previous pull request. Build the object out to contain the session_count in addition to the game object because you can never have enough data.