### PR TITLE
Fix Heroku Deploys For Rails Backend

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+rails=https://github.com/heroku/heroku-buildpack-ruby.git

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -18,8 +18,8 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use unicorn as the app server
-# gem 'unicorn'
+# Use puma as the app server
+gem 'puma'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     orm_adapter (0.5.0)
     pg (0.18.4)
     pkg-config (1.1.7)
+    puma (3.6.0)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -144,6 +145,7 @@ DEPENDENCIES
   devise_token_auth
   omniauth
   pg
+  puma
   rack-cors
   rails (= 4.2.6)
   responders (= 2.2.0)

--- a/rails/Procfile
+++ b/rails/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/rails/config/puma.rb
+++ b/rails/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Heroku has been broken since the folder refactoring splitting the front end from the backend. This fixes just the Rails side of things and includes both Heroku config updates as well as code changes. The previous buildpack was changed to the default ruby buildpack as we are no longer compiling the javascript/front end simultaneously.

* [Heroku] Change default buildpack to support [multiple buildpacks via subdirectory](https://github.com/negativetwelve/heroku-buildpack-subdir).
* [Code] Add `.buildpacks` file in root to control the subdirectories and how they are deployed.
* [Code] Per warning in Heroku, updated the web server from the default and built-in WEBrick to Puma as WEBRick is single-threaded and single-process. Created Puma config file with defaults.
* [Heroku] Created default config values for `MIN_THREADS` and `RAILS_MAX_THREADS` to 1 as we have not yet confirmed whether our app is thread safe.