### PR TITLE
Add Rails And "Full-Stack" Deployment To Grunt Tasks

### DIFF
--- a/angular/gulp/client.js
+++ b/angular/gulp/client.js
@@ -3,6 +3,20 @@ var webpack = require('webpack-stream');
 var templateCache = require('gulp-angular-templatecache');
 var browserSync = require('browser-sync');
 
+function browserSyncInit(baseDir, browser) {
+  browser = browser === undefined ? 'default' : browser;
+
+  var server = {
+    baseDir: baseDir
+  };
+
+  browserSync.instance = browserSync.init({
+    server: server,
+    browser: browser,
+    port: '8888'
+  });
+}
+
 gulp.task('views', function() {
   gulp.src(['index.html'])
     .pipe(gulp.dest('build/'))
@@ -28,12 +42,7 @@ return gulp.src('css/**/*.css')
 });
 
 gulp.task('serve', function() {
-  browserSync.init({
-    server: {
-      baseDir: './build'
-    },
-    port: '8888'
-  })
+  browserSyncInit('./build', []);
 });
 
 gulp.task('client', ['views', 'webpack', 'styles', 'serve']);

--- a/angular/gulp/client.js
+++ b/angular/gulp/client.js
@@ -2,6 +2,8 @@ var gulp = require('gulp');
 var webpack = require('webpack-stream');
 var templateCache = require('gulp-angular-templatecache');
 var browserSync = require('browser-sync');
+var path = require('path');
+var conf = require('./conf');
 
 function browserSyncInit(baseDir, browser) {
   browser = browser === undefined ? 'default' : browser;
@@ -13,36 +15,36 @@ function browserSyncInit(baseDir, browser) {
   browserSync.instance = browserSync.init({
     server: server,
     browser: browser,
-    port: '8888'
+    port: conf.ports.client
   });
 }
 
 gulp.task('views', function() {
   gulp.src(['index.html'])
-    .pipe(gulp.dest('build/'))
+  .pipe(gulp.dest(conf.clientPaths.build))
 
-  return gulp.src('app/templates/**/*.html')
+  return gulp.src(path.join(conf.clientPaths.app, 'templates/**/*.html'))
     .pipe(templateCache({
       moduleSystem: 'browserify',
       templateHeader: 'function($templateCache) {\n',
       templateFooter: '\n}\nmodule.exports.$inject = ["$templateCache"];'
     }))
-    .pipe(gulp.dest('app'));
+    .pipe(gulp.dest(conf.clientPaths.app));
 });
 
 gulp.task('webpack', ['views'], function() {
-  return gulp.src('app/app.js.coffee')
+  return gulp.src(path.join(conf.clientPaths.app, 'app.js.coffee'))
     .pipe(webpack(require('../webpack.config.js')))
-    .pipe(gulp.dest('build/js/'));
+    .pipe(gulp.dest(path.join(conf.clientPaths.build, 'js/')));
 });
 
 gulp.task('styles', function() {
 return gulp.src('css/**/*.css')
-    .pipe(gulp.dest('build/css/'));
+    .pipe(gulp.dest(path.join(conf.clientPaths.build, 'css/')));
 });
 
 gulp.task('serve', function() {
-  browserSyncInit('./build', []);
+  browserSyncInit('./' + conf.clientPaths.build, []);
 });
 
 gulp.task('client', ['views', 'webpack', 'styles', 'serve']);

--- a/angular/gulp/client.js
+++ b/angular/gulp/client.js
@@ -36,4 +36,4 @@ gulp.task('serve', function() {
   })
 });
 
-gulp.task('dev', ['views', 'webpack', 'styles', 'serve']);
+gulp.task('client', ['views', 'webpack', 'styles', 'serve']);

--- a/angular/gulp/client.js
+++ b/angular/gulp/client.js
@@ -1,0 +1,39 @@
+var gulp = require('gulp');
+var webpack = require('webpack-stream');
+var templateCache = require('gulp-angular-templatecache');
+var browserSync = require('browser-sync');
+
+gulp.task('views', function() {
+  gulp.src(['index.html'])
+    .pipe(gulp.dest('build/'))
+
+  return gulp.src('app/templates/**/*.html')
+    .pipe(templateCache({
+      moduleSystem: 'browserify',
+      templateHeader: 'function($templateCache) {\n',
+      templateFooter: '\n}\nmodule.exports.$inject = ["$templateCache"];'
+    }))
+    .pipe(gulp.dest('app'));
+});
+
+gulp.task('webpack', ['views'], function() {
+  return gulp.src('app/app.js.coffee')
+    .pipe(webpack(require('../webpack.config.js')))
+    .pipe(gulp.dest('build/js/'));
+});
+
+gulp.task('styles', function() {
+return gulp.src('css/**/*.css')
+    .pipe(gulp.dest('build/css/'));
+});
+
+gulp.task('serve', function() {
+  browserSync.init({
+    server: {
+      baseDir: './build'
+    },
+    port: '8888'
+  })
+});
+
+gulp.task('dev', ['views', 'webpack', 'styles', 'serve']);

--- a/angular/gulp/conf.js
+++ b/angular/gulp/conf.js
@@ -1,0 +1,9 @@
+module.exports = {
+  clientPaths: {
+    build: 'build',
+    app: 'app',
+  },
+  ports: {
+      client: 8888
+  }
+}

--- a/angular/gulp/server.js
+++ b/angular/gulp/server.js
@@ -1,0 +1,23 @@
+var gulp = require('gulp');
+var spawn = require('child_process').spawn;
+
+gulp.task('rails', function() {
+  var options = { cwd: '../rails' };
+  const rails = spawn('rails', ['server'], options);
+
+  rails.stdout.on('data', (data) => {
+    console.log(`stdout: ${data}`);
+  });
+
+  rails.stderr.on('data', (data) => {
+    console.log(`stderr: ${data}`);
+  });
+
+  rails.on('close', (code) => {
+    console.log(`child process exited with code ${code}`);
+  });
+
+  rails.on('error', (err) => {
+    console.log('Failed to start child process. ' + err);
+  });
+})

--- a/angular/gulpfile.js
+++ b/angular/gulpfile.js
@@ -10,3 +10,5 @@ fs.readdirSync('./gulp').filter(function(file) {
 }).map(function(file) {
   require('./gulp/' + file);
 });
+
+gulp.task('default', ['client']);

--- a/angular/gulpfile.js
+++ b/angular/gulpfile.js
@@ -1,31 +1,12 @@
+var fs = require('fs');
 var gulp = require('gulp');
-var webpack = require('webpack-stream');
-var templateCache = require('gulp-angular-templatecache');
-var browserSync = require('browser-sync');
 
-gulp.task('views', function() {
-  gulp.src(['index.html'])
-    .pipe(gulp.dest('build/'))
+/**
+ *  This will load all js or coffee files in the gulp directory
+ *  in order to load all gulp tasks
+ */
+fs.readdirSync('./gulp').filter(function(file) {
+  return (/\.(js|coffee)$/i).test(file);
+}).map(function(file) {
+  require('./gulp/' + file);
 });
-
-gulp.task('webpack', ['views'], function() {
-  return gulp.src('app/app.js.coffee')
-    .pipe(webpack(require('./webpack.config.js')))
-    .pipe(gulp.dest('build/js/'));
-});
-
-gulp.task('styles', function() {
-  return gulp.src('css/**/*.css')
-    .pipe(gulp.dest('build/css/'));
-});
-
-gulp.task('serve', function() {
-  browserSync.init({
-    server: {
-      baseDir: './build'
-    },
-    port: '8888'
-  })
-});
-
-gulp.task('dev', ['views', 'webpack', 'styles', 'serve']);

--- a/angular/gulpfile.js
+++ b/angular/gulpfile.js
@@ -11,4 +11,6 @@ fs.readdirSync('./gulp').filter(function(file) {
   require('./gulp/' + file);
 });
 
-gulp.task('default', ['client']);
+gulp.task('serve:full-stack', ['rails', 'client']);
+
+gulp.task('default', ['serve:full-stack']);

--- a/angular/package.json
+++ b/angular/package.json
@@ -24,6 +24,7 @@
     "angular-animate": "^1.5.8",
     "angular-aria": "^1.5.8",
     "angular-material": "^1.1.1",
-    "raw-loader": "^0.5.1"
+    "raw-loader": "^0.5.1",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
* Refactored existing gulp tasks into separate gulp files in a gulp folder
* Created `gulp rails` task to spin up rails puma server.
* Created `gulp server:full-stack` task to spin up both rails and angular

The `gulp rails` task will spawn a child process (actually 2 currently based upon puma config) using puma config. The output is piped to the command line. Killing the gulp task via `CTRL+C` or the like will kill those child processes as well.

Note this hasn't been tested in Heroku yet.